### PR TITLE
fix(results): Typo in array dict

### DIFF
--- a/honeybee_radiance_postprocess/results.py
+++ b/honeybee_radiance_postprocess/results.py
@@ -213,7 +213,7 @@ class Results(_ResultsFolder):
                               extension=extension)
         array = np.load(file)
 
-        array_dict = {grid_id: {light_path: {state: {type: array}}}}
+        array_dict = {grid_id: {light_path: {state_identifier: {type: array}}}}
         arrays = merge_dicts(array_dict, self.arrays)
         self.arrays = arrays
 


### PR DESCRIPTION
This causes 'array_from_states' to load the array from file everytime, instead of taking from the arrays dict, resulting in astronomical runtime.