### PR TITLE
fix(annual metrics): write config file to the correct place

### DIFF
--- a/honeybee_radiance_postprocess/results.py
+++ b/honeybee_radiance_postprocess/results.py
@@ -363,7 +363,7 @@ class Results(_ResultsFolder):
             info_file.write_text(json.dumps(grids_info))
 
         config = config or _annual_daylight_config()
-        config_file = folder.joinpath(metric, 'config.json')
+        config_file = folder.joinpath('config.json')
         config_file.write_text(json.dumps(config))
 
     def point_in_time(


### PR DESCRIPTION
I was writing it under the UDI folder. It should go under the parent folder for results.