### PR TITLE
fix(ci): Add sleep for PyPI update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,10 @@ jobs:
           PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: sleep for 5 minutes for PyPI update
+        if: contains(steps.new_release.outputs.tag, '.')
+        run: sleep 300s
+        shell: bash
       - name: Update pollination-honeybee-radiance-postprocess
         if: contains(steps.new_release.outputs.tag, '.')
         env:


### PR DESCRIPTION
This was causing problems when bumping the dependency in `pollination-honeybee-radiance-postprocess`.